### PR TITLE
Filtro para cursos en la preinscripción

### DIFF
--- a/css/guarani-helper.css
+++ b/css/guarani-helper.css
@@ -138,3 +138,8 @@
     display: inline;
     text-decoration: none;
 }
+
+/** Some other css is breaking this so it's enforced here*/
+form#filters label {
+    display: initial;
+}

--- a/js/guarani/Consts.js
+++ b/js/guarani/Consts.js
@@ -61,4 +61,26 @@ UtnBaHelper.Consts = {
 		10: 10
 	},
 
+	dictModalidad: {
+        "presencial": "sede",
+        "virtual": "virtual"
+    },
+
+    dictDuracion: {
+        "anual": "anual",
+        "cuatrimestral": "cuatrimestre"
+    },
+
+    dictTurno: {
+        "mañana": "(m)",
+        "tarde": "(t)",
+        "noche": "(n)"
+    },
+
+    dictAll : {
+        ...dictModalidad,
+        ...dictDuracion,
+        ...dictTurno
+    }
+
 };

--- a/js/guarani/pages/PreInscripcionPage.js
+++ b/js/guarani/pages/PreInscripcionPage.js
@@ -166,26 +166,26 @@ UtnBaHelper.PreInscripcionPage = function (pagesDataParser, utils, apiConnector)
 	};
 
 
-	let addPreviousProfessorsTableEventFn;
+	let modifyPreinscriptionPageFn;
 	return {
 		init: function () {
 			return Promise.resolve().then(() => {
 				// Need to listen to course register changes, as the combo is reloaded, and we need to add the table again.
 				// We need to un register them on close, as changing a course will trigger a new PreInscripcionPage.
 				// Events triggered from foreground script:
-				addPreviousProfessorsTableEventFn = () => {
+				modifyPreinscriptionPageFn = () => {
 					utils.runAsync("addPreviousProfessorsTable", addPreviousProfessorsTable);
 					utils.runAsync("addComissionsFilter", addComissionsFilter);
 				}
-				window.addEventListener("__utn_ba_event_comision_preinscripta", addPreviousProfessorsTableEventFn);
-				window.addEventListener("__utn_ba_event_comision_despreinscripta", addPreviousProfessorsTableEventFn);
+				window.addEventListener("__utn_ba_event_comision_preinscripta", modifyPreinscriptionPageFn);
+				window.addEventListener("__utn_ba_event_comision_despreinscripta", modifyPreinscriptionPageFn);
 
 				return addPreviousProfessorsTable();
 			});
 		},
 		close: function () {
-			window.removeEventListener("__utn_ba_event_comision_preinscripta", addPreviousProfessorsTableEventFn);
-			window.removeEventListener("__utn_ba_event_comision_despreinscripta", addPreviousProfessorsTableEventFn);
+			window.removeEventListener("__utn_ba_event_comision_preinscripta", modifyPreinscriptionPageFn);
+			window.removeEventListener("__utn_ba_event_comision_despreinscripta", modifyPreinscriptionPageFn);
 		},
 	};
 };

--- a/js/guarani/pages/PreInscripcionPage.js
+++ b/js/guarani/pages/PreInscripcionPage.js
@@ -21,10 +21,10 @@ UtnBaHelper.PreInscripcionPage = function (pagesDataParser, utils, apiConnector)
 	};
 
 	let addComissionsFilter = function() {
-		const header = document.querySelector('#insc_alternativas h2');
+		const header = document.querySelector('#insc_alternativas .inscripcion-alternativa');
 
 		// Adds the checkboxes html
-		header.insertAdjacentHTML('afterend', 
+		header.insertAdjacentHTML("beforebegin",
 		`<form id="filters"">
 
         <div class='modalidad'>

--- a/js/guarani/pages/PreInscripcionPage.js
+++ b/js/guarani/pages/PreInscripcionPage.js
@@ -44,34 +44,28 @@ UtnBaHelper.PreInscripcionPage = function (pagesDataParser, utils, apiConnector)
 
 		// Adds the checkboxes html
 		header.insertAdjacentHTML('afterend', 
-		`<form id="filters">
+		`<form id="filters"">
 
         <div class='modalidad'>
-            <input type="radio" id="todos" name="filtro_modalidad" value="todos" checked>
-            <label for="todos">todas</label>
-            <input type="radio" id="presencial" name="filtro_modalidad" value="presencial">
+            <input type="checkbox" checked id="presencial" name="filtro_modalidad" value="presencial">
             <label for="presencial">presencial</label>
-            <input type="radio" id="virtual" name="filtro_modalidad" value="virtual">
+            <input type="checkbox" checked id="virtual" name="filtro_modalidad" value="virtual">
             <label for="virtual">virtual</label>
         </div>
 
         <div class='duracion'>
-            <input type="radio" id="todos" name="filtro_duracion" value="todos" checked>
-            <label for="todos">todas</label>
-            <input type="radio" id="anual" name="filtro_duracion" value="anual">
+            <input type="checkbox" checked id="anual" name="filtro_duracion" value="anual">
             <label for="anual">anual</label>
-            <input type="radio" id="cuatrimestral" name="filtro_duracion" value="cuatrimestral">
+            <input type="checkbox" checked id="cuatrimestral" name="filtro_duracion" value="cuatrimestral">
             <label for="cuatrimestral">cuatrimestral</label>
         </div>
 
         <div class='turno'>
-            <input type="radio" id="todos" name="filtro_turno" value="todos" checked>
-            <label for="todos">todos</label>
-            <input type="radio" id="mañana" name="filtro_turno" value="mañana">
+            <input type="checkbox" checked id="mañana" name="filtro_turno" value="mañana">
             <label for="mañana">mañana</label>
-            <input type="radio" id="tarde" name="filtro_turno" value="tarde">
+            <input type="checkbox" checked id="tarde" name="filtro_turno" value="tarde">
             <label for="tarde">tarde</label>
-            <input type="radio" id="noche" name="filtro_turno" value="noche">
+            <input type="checkbox" checked id="noche" name="filtro_turno" value="noche">
             <label for="noche">noche</label>
         </div>
 
@@ -82,9 +76,9 @@ UtnBaHelper.PreInscripcionPage = function (pagesDataParser, utils, apiConnector)
 		document.querySelector('#filters').addEventListener('submit', (event) => {
 			event.preventDefault();
 
-			const modalidades = Array.from(document.querySelectorAll('#filtros .modalidad input:checked')).map(elmnt => dictAll[elmnt.value]);
-			const duraciones = Array.from(document.querySelectorAll('#filtros .duracion input:checked')).map(elmnt => dictAll[elmnt.value]);
-			const turnos = Array.from(document.querySelectorAll('#filtros .turno input:checked')).map(elmnt => dictAll[elmnt.value]);
+			const modalidades = Array.from(document.querySelectorAll('#filters .modalidad input:checked')).map(elmnt => dictAll[elmnt.value]);
+			const duraciones = Array.from(document.querySelectorAll('#filters .duracion input:checked')).map(elmnt => dictAll[elmnt.value]);
+			const turnos = Array.from(document.querySelectorAll('#filters .turno input:checked')).map(elmnt => dictAll[elmnt.value]);
 	
 			const filteredOptions = selectOptions
 				.filter(option => modalidades.some(value => option.text.toLowerCase().includes(value)))

--- a/js/guarani/pages/PreInscripcionPage.js
+++ b/js/guarani/pages/PreInscripcionPage.js
@@ -1,27 +1,8 @@
+
 if (!window.UtnBaHelper) window.UtnBaHelper = {};
 UtnBaHelper.PreInscripcionPage = function (pagesDataParser, utils, apiConnector) {
 
-	const dictModalidad = {
-        "presencial": "sede",
-        "virtual": "virtual"
-    }
-
-    const dictDuracion = {
-        "anual": "anual",
-        "cuatrimestral": "cuatrimestre"
-    }
-
-    const dictTurno = {
-        "mañana": "(m)",
-        "tarde": "(t)",
-        "noche": "(n)"
-    }
-
-    const dictAll = {
-        ...dictModalidad,
-        ...dictDuracion,
-        ...dictTurno
-    }
+	const { dictAll } = UtnBaHelper.Consts;
 
 	const outletOptions = document.querySelector('#comision');
 


### PR DESCRIPTION
Siendo ahora el momento de preinscripción, me pareció bueno que se pueda agregar unos filtros sobre los 3 criterios que uno puede llegar a buscar: 
- **Modalidad (presencial, virtual)**
- **Duración (cuatrimestral, anual)**
- **Turno (Mañana, Tarde, Noche)**

Así que agrego un par de checkboxes en la página de Preinscripción, que te deja realizar ese filtrado. Creo que lo enganché al evento que crea la tabla de puntajes de cada materia por lo que debería correr a la par; renombrando la función para que corra ambas cosas.

Lo hice bastante a pulmón porque localmente revienta en varios lados al no poder pegarle a la BASE_URL que es "https://www.pablomatiasgomez.com.ar/utnba-helper/v2", asumo que está bien para que no te haga una sobrecarga de llamadas a la API? Pero como tira un par de errores parece que no llega a la parte que quiero que corra.

Se le puede mejorar un poquito la UI pero por ahora lo dejo así, incluso con el `console.log` porque no confío del todo que ande bien por los errores que menciono arriba. Pero dejo un GIF de cómo anda después de insertar todo a mano en el HTML del SIU.
![Prueba](https://user-images.githubusercontent.com/5074186/223317986-032e1e84-f2a4-4c52-8e6a-91ea9f22d2b2.gif)

