### PR TITLE
Mejora en contraste en tarjetas de cursos de la pagina "Seguimiento de Plan"

### DIFF
--- a/js/guarani/custompages/PlanTrackingCustomPage.js
+++ b/js/guarani/custompages/PlanTrackingCustomPage.js
@@ -126,19 +126,21 @@ UtnBaHelper.PlanTrackingCustomPage = function ($container, services) {
 				return courseWeight(c2) - courseWeight(c1);
 			}).map(course => {
 				let status;
-				let color = "#7e7e7e";
+				let backgroundColor = "#7e7e7e";
+				let color = "#000000";
 				if (course.isPassed) {
 					status = TRANSLATIONS["PASSED"];
-					color = "#55bb55";
+					backgroundColor = "#55bb55";
 				} else if (course.canTakeFinalExam) {
 					status = "Puede " + TRANSLATIONS["TAKE_FINAL_EXAM"].toLowerCase();
-					color = "#ffcc00";
+					backgroundColor = "#ffcc00";
 				} else if (course.isSigned) {
 					status = TRANSLATIONS["SIGNED"];
-					color = "#ffcc00";
+					backgroundColor = "#ffcc00";
 				} else if (course.canRegister) {
 					status = "Puede " + TRANSLATIONS["REGISTER"].toLowerCase();
-					color = "#5555bb";
+					backgroundColor = "#5555bb";
+					color = "#f1f1f1";
 				}
 
 				let hr = "";
@@ -169,7 +171,7 @@ UtnBaHelper.PlanTrackingCustomPage = function ($container, services) {
 				return `
 					${hr}
 					${showExtraElectivesButton}
-					<div class="course level-${level} ${divClass}" style="background-color:${color};">
+					<div class="course level-${level} ${divClass}" style="background-color:${backgroundColor};color:${color}">
 						<a href="#" onclick="return false" style="float: right;">
 							<i class="icon-info-sign"></i>
 							<span class="dependency-tooltip">


### PR DESCRIPTION
Buenas, se me estaba haciendo un poco molesto la falta de contraste en las tarjetas de los cursos en los que me puedo anotar (las que son violeta oscuro). Me encontre varias veces seleccionando el texto interno porque me costaba leerlo.
Aca te dejo una foto de como estan todos los casos actuales + como quedaria cambiado:
<img width="257" alt="image" src="https://user-images.githubusercontent.com/37568902/227726982-f4225fe0-7385-4a3c-b85f-c5684bedbfbf.png">
En el resto de los casos el contraste es adecuado.

- Agrego soporte para cambiar color de letra segun el caso
- Agrego color de letra para las tarjetas de "puedo anotarme", es un blanco no tan chillon
- Renombro la actual variable `color` a `backgroundColor`, que tiene un poco mas de sentido dado el contexto.