### PR TITLE
Agrego link a completar perfil en página de exámenes

### DIFF
--- a/js/guarani/main.js
+++ b/js/guarani/main.js
@@ -25,6 +25,7 @@
 			// match is performed using startsWith and first one is used.
 			"/autogestion/grado/calendario": () => UtnBaHelper.HorariosPage(),
 			"/autogestion/grado/cursada/elegir_materia/": () => UtnBaHelper.PreInscripcionPage(pagesDataParser, utils, apiConnector),
+			"/autogestion/grado/examen": () => UtnBaHelper.InscripcionAExamenesPage(),
 		};
 
 		let currentHandler = null;

--- a/js/guarani/pages/InscripcionAExamenesPage.js
+++ b/js/guarani/pages/InscripcionAExamenesPage.js
@@ -1,0 +1,30 @@
+if (!window.UtnBaHelper) window.UtnBaHelper = {};
+
+const textChild = document.createTextNode(" o haciendo click ")
+const redirectLink = document.createElement('a')
+redirectLink.href = "/autogestion/grado/datos_censales"
+redirectLink.textContent = "AQUÍ"
+
+UtnBaHelper.InscripcionAExamenesPage = function () {
+
+
+    const errorMessageSelector = document.querySelector('#lista_materias > div.alert.info.strong')
+
+    function replaceMessageIfExists() {
+        if (errorMessageSelector) {
+            errorMessageSelector.appendChild(textChild)
+            errorMessageSelector.appendChild(redirectLink)
+        }
+    }
+
+
+    return {
+        init: function () {
+            return Promise.resolve().then(() => {
+                replaceMessageIfExists();
+            });
+        },
+        close: function () {
+        },
+    };
+};

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -18,6 +18,7 @@ js/guarani/Store.js \
 js/guarani/DataCollector.js \
 js/guarani/PagesDataParser.js \
 js/guarani/pages/HorariosPage.js \
+js/guarani/pages/InscripcionAExamenesPage.js \
 js/guarani/pages/PreInscripcionPage.js \
 js/guarani/custompages/ProfessorsSearchCustomPage.js \
 js/guarani/custompages/CoursesSearchCustomPage.js \


### PR DESCRIPTION
Para inscribirse a exámenes, la plataforma pide actualizar la información del alumno una vez cada tanto (no sé si 6 meses o 1 año), así que agrego un link que va a donde se completa el perfil directamente ahí, para ir de un sólo click.

![cosa](https://github.com/pablomatiasgomez/utn.ba-helper/assets/5074186/ec4d6224-35e6-4a77-a04e-dd7c21242cfb)

